### PR TITLE
squid:S1118, squid:S1168 - Utility classes should not have public con…

### DIFF
--- a/src/main/java/com/github/stuxuhai/jpinyin/ChineseHelper.java
+++ b/src/main/java/com/github/stuxuhai/jpinyin/ChineseHelper.java
@@ -8,11 +8,12 @@ import java.util.Map.Entry;
  *
  * @author stuxuhai (dczxxuhai@gmail.com)
  */
-public class ChineseHelper {
+public final class ChineseHelper {
 
     private static final String CHINESE_REGEX = "[\\u4e00-\\u9fa5]";
     private static final Map<String, String> CHINESE_MAP = PinyinResource.getChineseResource();
 
+    private ChineseHelper() {}
     /**
      * 将单个繁体字转换为简体字
      * 

--- a/src/main/java/com/github/stuxuhai/jpinyin/PinyinHelper.java
+++ b/src/main/java/com/github/stuxuhai/jpinyin/PinyinHelper.java
@@ -8,13 +8,15 @@ import java.util.Map;
  *
  * @author stuxuhai (dczxxuhai@gmail.com)
  */
-public class PinyinHelper {
+public final class PinyinHelper {
     private static final Map<String, String> PINYIN_TABLE = PinyinResource.getPinyinResource();
     private static final Map<String, String> MUTIL_PINYIN_TABLE = PinyinResource.getMutilPinyinResource();
     private static final String PINYIN_SEPARATOR = ","; // 拼音分隔符
     private static final char CHINESE_LING = '〇';
     private static final String ALL_UNMARKED_VOWEL = "aeiouv";
     private static final String ALL_MARKED_VOWEL = "āáǎàēéěèīíǐìōóǒòūúǔùǖǘǚǜ"; // 所有带声调的拼音字母
+
+    private PinyinHelper() {}
 
     /**
      * 将带声调格式的拼音转换为数字代表声调格式的拼音
@@ -90,7 +92,7 @@ public class PinyinHelper {
         } else if (pinyinFormat == PinyinFormat.WITHOUT_TONE) {
             return convertWithoutTone(pinyinString);
         }
-        return null;
+        return new String[0];
     }
 
     /**
@@ -105,7 +107,7 @@ public class PinyinHelper {
         if ((pinyin != null) && (!pinyin.equals("null"))) {
             return formatPinyin(pinyin, pinyinFormat);
         }
-        return null;
+        return new String[0];
     }
 
     /**

--- a/src/main/java/com/github/stuxuhai/jpinyin/PinyinResource.java
+++ b/src/main/java/com/github/stuxuhai/jpinyin/PinyinResource.java
@@ -12,7 +12,9 @@ import java.util.Map;
  *
  * @author stuxuhai (dczxxuhai@gmail.com)
  */
-public class PinyinResource {
+public final class PinyinResource {
+
+    private PinyinResource() {}
 
     private static Map<String, String> getResource(String resourceName) {
         Map<String, String> map = new HashMap<String, String>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1118 - Utility classes should not have public constructors
squid:S1168 - Empty arrays and collections should be returned instead of null

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1168

Please let me know if you have any questions.

M-Ezzat