### PR TITLE
[squid:S1132] Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/src/main/java/com/github/stuxuhai/jpinyin/PinyinHelper.java
+++ b/src/main/java/com/github/stuxuhai/jpinyin/PinyinHelper.java
@@ -104,7 +104,7 @@ public final class PinyinHelper {
      */
     public static String[] convertToPinyinArray(char c, PinyinFormat pinyinFormat) {
         String pinyin = PINYIN_TABLE.get(String.valueOf(c));
-        if ((pinyin != null) && (!pinyin.equals("null"))) {
+        if ((pinyin != null) && (!"null".equals(pinyin))) {
             return formatPinyin(pinyin, pinyinFormat);
         }
         return new String[0];


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.
Ayman Abdelghany.